### PR TITLE
Skip DockerHub login if not pushing

### DIFF
--- a/.github/workflows/container.yaml
+++ b/.github/workflows/container.yaml
@@ -21,7 +21,8 @@ jobs:
         uses: actions/checkout@v2.4.0
 
       - name: Login to DockerHub
-        uses: docker/login-action@v1 
+        uses: docker/login-action@v1
+        if: ${{ github.repository == 'coralogix/coralogix-operator-poc' && github.event_name != 'pull_request' }}
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}


### PR DESCRIPTION
Skip logging if we're running CI on a PR. In this case, the login is not necessary and if a PR comes from a fork, the secrets are not available, making the CI run fail unnecessarily.